### PR TITLE
Data model for external accounts

### DIFF
--- a/external-accounts/README.md
+++ b/external-accounts/README.md
@@ -7,9 +7,20 @@
 ```
 {
   "type": string,
-  "token": string,
-  "accountId": string,
-  "timestamp": timestamp,
-  "expiry": timestamp,
+  "attributes" : object
+}
+```
+
+### Example
+- For Discord Accounts
+```
+{
+  "type": string,
+  "attributes" : {
+    "token": string,
+    "accountId": string,
+    "timestamp": timestamp,
+    "expiry": timestamp,
+  }
 }
 ```

--- a/external-accounts/README.md
+++ b/external-accounts/README.md
@@ -1,15 +1,15 @@
-# Discord
+# External Accounts
 
 ## Firestore collection:
 
-- discord
+- external-accounts
 
 ```
 {
+  "type": string,
   "token": string,
-  "discordId": string,
+  "accountId": string,
   "timestamp": timestamp,
   "expiry": timestamp,
-  "linkStatus": boolean
 }
 ```

--- a/external-accounts/README.md
+++ b/external-accounts/README.md
@@ -7,6 +7,8 @@
 ```
 {
   "type": string,
+  "token": string,
+  "createdOn": timestamp,
   "attributes" : object
 }
 ```
@@ -16,10 +18,10 @@
 ```
 {
   "type": string,
+  "token": string,
+  "createdOn": timestamp,
   "attributes" : {
-    "token": string,
     "discordId": string,
-    "timestamp": timestamp,
     "expiry": timestamp,
   }
 }

--- a/external-accounts/README.md
+++ b/external-accounts/README.md
@@ -18,7 +18,7 @@
   "type": string,
   "attributes" : {
     "token": string,
-    "accountId": string,
+    "discordId": string,
     "timestamp": timestamp,
     "expiry": timestamp,
   }


### PR DESCRIPTION
## What's the change
- Refactoring has been done for the Discord Model and made it generic for all external accounts
- `Discord` changed to `External Accounts`
- `timestamp` changed to `createdOn`
- Added `attributes` object
- `linkStatus` is not required now

## Note for the reviewer
- These changes are a part of refactor Check here for reference https://github.com/Real-Dev-Squad/website-data-models/tree/main/discord