### PR TITLE
Adds trackedProgresses collection data model for user and task progress

### DIFF
--- a/tracked-progresses/README.md
+++ b/tracked-progresses/README.md
@@ -23,7 +23,7 @@ User trackedProgresses Document
   "type": "user",
   "userId": "hPz5hfWBd9oSwMljGk1s",
   "frequency": 1,
-  "currentlyTracked": True,
+  "currentlyTracked": true,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }
@@ -37,7 +37,7 @@ Task trackedProgresses Document
   "type": "task",
   "taskId": "t5k77PHnuDSrgEzvMJAj",
   "frequency": 4,
-  "currentlyTracked": False,
+  "currentlyTracked": false,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }

--- a/tracked-progresses/README.md
+++ b/tracked-progresses/README.md
@@ -1,0 +1,41 @@
+# Firestore collection (trackedProgresses) Data Model
+
+```json
+{
+  "id": "Unique identifier for the document. (String)",
+  "type": "Type of the document, i.e task or user. (String)",
+  "userId": "The id of the user, will be applicable only for user. (String)",
+  "taskId": "The id of the task, will be applicable only for task. (String)",
+  "frequency": "The frequency at which the item is being tracked, expressed as a positive integer. For example, a frequency of 1 represents daily tracking, a frequency of 7 represents weekly tracking, and so on. If not specified, a default value of 1 will be used for tasks. For Users it will always be 1. (Number)",
+  "createdAt": "The timestamp indicating the creation time of the trackedProgresses document. (ISO 8601 format)",
+  "updatedAt": "The timestamp indicating the last update time of the trackedProgresses document. (ISO 8601 format)"
+}
+```
+
+## Example
+
+User trackedProgresses Document
+
+```json
+{
+  "id": "eBe01VS3oYI2HJuWdRuG",
+  "type": "user",
+  "userId": "abc123",
+  "frequency": 1,
+  "createdAt": "2023-05-16T14:35:00Z",
+  "updatedAt": "2023-05-16T14:35:00Z"
+}
+```
+
+Task trackedProgresses Document
+
+```json
+{
+  "id": "en7nlNnpfqoqodcmtMeZ",
+  "type": "task",
+  "taskId": "abc123",
+  "frequency": 4,
+  "createdAt": "2023-05-16T14:35:00Z",
+  "updatedAt": "2023-05-16T14:35:00Z"
+}
+```

--- a/tracked-progresses/README.md
+++ b/tracked-progresses/README.md
@@ -6,6 +6,7 @@
   "type": "Type of the document, i.e task or user. (String)",
   "userId": "The id of the user, will be applicable only for user. (String)",
   "taskId": "The id of the task, will be applicable only for task. (String)",
+  "currentlyTracked": "A boolean indicating whether the item is currently being tracked or not. (Boolean)",
   "frequency": "The frequency at which the item is being tracked, expressed as a positive integer. For example, a frequency of 1 represents daily tracking, a frequency of 7 represents weekly tracking, and so on. If not specified, a default value of 1 will be used for tasks. For Users it will always be 1. (Number)",
   "createdAt": "The timestamp indicating the creation time of the trackedProgresses document. (ISO 8601 format)",
   "updatedAt": "The timestamp indicating the last update time of the trackedProgresses document. (ISO 8601 format)"
@@ -20,8 +21,9 @@ User trackedProgresses Document
 {
   "id": "eBe01VS3oYI2HJuWdRuG",
   "type": "user",
-  "userId": "abc123",
+  "userId": "hPz5hfWBd9oSwMljGk1s",
   "frequency": 1,
+  "currentlyTracked": True,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }
@@ -33,8 +35,9 @@ Task trackedProgresses Document
 {
   "id": "en7nlNnpfqoqodcmtMeZ",
   "type": "task",
-  "taskId": "abc123",
+  "taskId": "t5k77PHnuDSrgEzvMJAj",
   "frequency": 4,
+  "currentlyTracked": False,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }


### PR DESCRIPTION
This PR adds a data model for the new collection called `trackedProgresses` to store information about which users or tasks are being tracked by the superuser. The collection includes fields for the `type`, `userId`, `taskId`, `frequency`, `currentlyTracked`,`createdAt`, and `updatedAt` of each tracked item.

The parent ticket can be found here [here](https://github.com/Real-Dev-Squad/website-backend/issues/1076)
