### PR TITLE
changed field name from currentlyTracked to monitored

### DIFF
--- a/tracked-progresses/README.md
+++ b/tracked-progresses/README.md
@@ -6,7 +6,7 @@
   "type": "Type of the document, i.e task or user. (String)",
   "userId": "The id of the user, will be applicable only for user. (String)",
   "taskId": "The id of the task, will be applicable only for task. (String)",
-  "marked": "A boolean indicating whether the item is currently being tracked or not. (Boolean)",
+  "monitored": "A boolean indicating whether the item is currently being tracked or not. (Boolean)",
   "frequency": "The frequency at which the item is being tracked, expressed as a positive integer. For example, a frequency of 1 represents daily tracking, a frequency of 7 represents weekly tracking, and so on. If not specified, a default value of 1 will be used for tasks. For Users it will always be 1. (Number)",
   "createdAt": "The timestamp indicating the creation time of the trackedProgresses document. (ISO 8601 format)",
   "updatedAt": "The timestamp indicating the last update time of the trackedProgresses document. (ISO 8601 format)"
@@ -23,7 +23,7 @@ User trackedProgresses Document
   "type": "user",
   "userId": "hPz5hfWBd9oSwMljGk1s",
   "frequency": 1,
-  "marked": true,
+  "monitored": true,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }
@@ -37,7 +37,7 @@ Task trackedProgresses Document
   "type": "task",
   "taskId": "t5k77PHnuDSrgEzvMJAj",
   "frequency": 4,
-  "marked": false,
+  "monitored": false,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }

--- a/tracked-progresses/README.md
+++ b/tracked-progresses/README.md
@@ -6,7 +6,7 @@
   "type": "Type of the document, i.e task or user. (String)",
   "userId": "The id of the user, will be applicable only for user. (String)",
   "taskId": "The id of the task, will be applicable only for task. (String)",
-  "currentlyTracked": "A boolean indicating whether the item is currently being tracked or not. (Boolean)",
+  "marked": "A boolean indicating whether the item is currently being tracked or not. (Boolean)",
   "frequency": "The frequency at which the item is being tracked, expressed as a positive integer. For example, a frequency of 1 represents daily tracking, a frequency of 7 represents weekly tracking, and so on. If not specified, a default value of 1 will be used for tasks. For Users it will always be 1. (Number)",
   "createdAt": "The timestamp indicating the creation time of the trackedProgresses document. (ISO 8601 format)",
   "updatedAt": "The timestamp indicating the last update time of the trackedProgresses document. (ISO 8601 format)"
@@ -23,7 +23,7 @@ User trackedProgresses Document
   "type": "user",
   "userId": "hPz5hfWBd9oSwMljGk1s",
   "frequency": 1,
-  "currentlyTracked": true,
+  "marked": true,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }
@@ -37,7 +37,7 @@ Task trackedProgresses Document
   "type": "task",
   "taskId": "t5k77PHnuDSrgEzvMJAj",
   "frequency": 4,
-  "currentlyTracked": false,
+  "marked": false,
   "createdAt": "2023-05-16T14:35:00Z",
   "updatedAt": "2023-05-16T14:35:00Z"
 }


### PR DESCRIPTION
This PR updates the field name in the `trackedProgresses` collection from `currentlyTracked` to `monitored `. The field represents whether an item is currently being tracked or not. The change provides a more descriptive and intuitive name for the field.