### PR TITLE
DOC: Add OOO Status Request Firestore Collection Model

### DIFF
--- a/ooo-request/README.md
+++ b/ooo-request/README.md
@@ -4,41 +4,31 @@
 {
   "id": "String",
   "userId": "String",
-  "state": "PENDING",
+  "state": "PENDING" | "APPROVED" | "REJECTED",
   "from": "Timestamp",
   "until": "Timestamp",
   "message": "String",
   "createdAt": "Timestamp",
   "updatedAt": "Timestamp",
-  // after approval
-  "state": "APPROVED",
-  "approvedAt": "Timestamp",
-  "approvedBy": "String",
-  // after rejection
-  "state": "REJECTED",
-  "rejectedAt": "Timestamp",
-  "rejectedBy": "String",
-  "rejectedReason": "String"
+  "processedBy": "String",
+  "reason": "String"
 }
 ```
 
 #### Fields
 
-| Field          | Type      | Description                                             |
-| -------------- | --------- | ------------------------------------------------------- |
-| id             | String    | Unique identifier for the document.                     |
-| userId         | String    | The id of the user.                                     |
-| state          | String    | The state of the request.                               |
-| from           | Timestamp | Unix timestamp for the start date of the request.       |
-| until          | Timestamp | Unix timestamp for the end date of the request.         |
-| message        | String    | The message for the request.                            |
-| createdAt      | Timestamp | Unix timestamp for the creation time of the request.    |
-| updatedAt      | Timestamp | Unix timestamp for the last update time of the request. |
-| approvedAt     | Timestamp | Unix timestamp for the approval time of the request.    |
-| approvedBy     | String    | The id of the user who approved the request.            |
-| rejectedAt     | Timestamp | Unix timestamp for the rejection time of the request.   |
-| rejectedBy     | String    | The id of the user who rejected the request.            |
-| rejectedReason | String    | The reason for the rejection of the request.            |
+| Field       | Type      | Description                                                |
+| ----------- | --------- | ---------------------------------------------------------- |
+| id          | String    | Unique identifier for the document.                        |
+| userId      | String    | The id of the user who created the request.                |
+| state       | String    | The state of the request like APPROVED, REJECTED, PENDING. |
+| from        | Timestamp | Unix timestamp for the start date of the OOO request.      |
+| until       | Timestamp | Unix timestamp for the end date of the OOO request.        |
+| message     | String    | The message for the request.                               |
+| createdAt   | Timestamp | Unix timestamp for the creation time of the request.       |
+| updatedAt   | Timestamp | Unix timestamp for the last update time of the request.    |
+| processedBy | String    | The id of the user who processed the request.              |
+| reason      | String    | The reason for the request.                                |
 
 ### Example data
 
@@ -65,8 +55,8 @@
   "message": "Attending a work conference.",
   "createdAt": 1709525400000,
   "updatedAt": 1709827800000,
-  "approvedAt": 1709827800000,
-  "approvedBy": "Sedv5T1Tlid4Y6Y0d"
+  "processedBy": "Sedv5T1Tlid4Y6Y0d",
+  "reason": "Nice to have you back."
 }
 
 // Example for REJECTED state
@@ -79,9 +69,8 @@
   "message": "Out of office for personal reasons.",
   "createdAt": 1708763200000,
   "updatedAt": 1708841500000,
-  "rejectedAt": 1708841500000,
-  "rejectedBy": "Sedv5T1Tlid4Y6Y0d",
-  "rejectedReason": "Not enough notice."
+  "processedBy": "Sedv5T1Tlid4Y6Y0d",
+  "reason": "Not enough vacation days."
 }
 
 ```

--- a/ooo-request/README.md
+++ b/ooo-request/README.md
@@ -10,25 +10,25 @@
   "message": "String",
   "createdAt": "Timestamp",
   "updatedAt": "Timestamp",
-  "processedBy": "String",
+  "lastUpdatedBy": "String",
   "reason": "String"
 }
 ```
 
 #### Fields
 
-| Field       | Type      | Description                                                |
-| ----------- | --------- | ---------------------------------------------------------- |
-| id          | String    | Unique identifier for the document.                        |
-| userId      | String    | The id of the user who created the request.                |
-| state       | String    | The state of the request like APPROVED, REJECTED, PENDING. |
-| from        | Timestamp | Unix timestamp for the start date of the OOO request.      |
-| until       | Timestamp | Unix timestamp for the end date of the OOO request.        |
-| message     | String    | The message for the request.                               |
-| createdAt   | Timestamp | Unix timestamp for the creation time of the request.       |
-| updatedAt   | Timestamp | Unix timestamp for the last update time of the request.    |
-| processedBy | String    | The id of the user who processed the request.              |
-| reason      | String    | The reason for the request.                                |
+| Field         | Type      | Description                                                |
+| ------------- | --------- | ---------------------------------------------------------- |
+| id            | String    | Unique identifier for the document.                        |
+| userId        | String    | The id of the user who created the request.                |
+| state         | String    | The state of the request like APPROVED, REJECTED, PENDING. |
+| from          | Timestamp | Unix timestamp for the start date of the OOO request.      |
+| until         | Timestamp | Unix timestamp for the end date of the OOO request.        |
+| message       | String    | The message for the request.                               |
+| createdAt     | Timestamp | Unix timestamp for the creation time of the request.       |
+| updatedAt     | Timestamp | Unix timestamp for the last update time of the request.    |
+| lastUpdatedBy | String    | The id of the superuser who processed the request          |
+| reason        | String    | The reason for the APPROVED or REJECTED.                   |
 
 ### Example data
 
@@ -59,7 +59,7 @@
   "message": "Attending a work conference.",
   "createdAt": 1709525400000,
   "updatedAt": 1709827800000,
-  "processedBy": "Sedv5T1Tlid4Y6Y0d",
+  "lastUpdatedBy": "Sedv5T1Tlid4Y6Y0d",
   "reason": "Nice to have you back."
 }
 ```
@@ -76,7 +76,7 @@
   "message": "Out of office for personal reasons.",
   "createdAt": 1708763200000,
   "updatedAt": 1708841500000,
-  "processedBy": "Sedv5T1Tlid4Y6Y0d",
+  "lastUpdatedBy": "Sedv5T1Tlid4Y6Y0d",
   "reason": "Not enough vacation days."
 }
 ```

--- a/ooo-request/README.md
+++ b/ooo-request/README.md
@@ -1,0 +1,87 @@
+### OOO Status request Firestore collection model
+
+```json
+{
+  "id": "String",
+  "userId": "String",
+  "state": "PENDING",
+  "from": "Timestamp",
+  "until": "Timestamp",
+  "message": "String",
+  "createdAt": "Timestamp",
+  "updatedAt": "Timestamp",
+  // after approval
+  "state": "APPROVED",
+  "approvedAt": "Timestamp",
+  "approvedBy": "String",
+  // after rejection
+  "state": "REJECTED",
+  "rejectedAt": "Timestamp",
+  "rejectedBy": "String",
+  "rejectedReason": "String"
+}
+```
+
+#### Fields
+
+| Field          | Type      | Description                                             |
+| -------------- | --------- | ------------------------------------------------------- |
+| id             | String    | Unique identifier for the document.                     |
+| userId         | String    | The id of the user.                                     |
+| state          | String    | The state of the request.                               |
+| from           | Timestamp | Unix timestamp for the start date of the request.       |
+| until          | Timestamp | Unix timestamp for the end date of the request.         |
+| message        | String    | The message for the request.                            |
+| createdAt      | Timestamp | Unix timestamp for the creation time of the request.    |
+| updatedAt      | Timestamp | Unix timestamp for the last update time of the request. |
+| approvedAt     | Timestamp | Unix timestamp for the approval time of the request.    |
+| approvedBy     | String    | The id of the user who approved the request.            |
+| rejectedAt     | Timestamp | Unix timestamp for the rejection time of the request.   |
+| rejectedBy     | String    | The id of the user who rejected the request.            |
+| rejectedReason | String    | The reason for the rejection of the request.            |
+
+### Example data
+
+```json
+// Example for PENDING state
+{
+  "id": "OfsT1Tlid4Y6Y0d",
+  "userId": "dfdsd5T1Tlid4Y6Y0d",
+  "state": "PENDING",
+  "from": 1709438800000,
+  "until": 1709870800000,
+  "message": "Out of office for personal reasons.",
+  "createdAt": 1709438900000,
+  "updatedAt": 1709438900000
+}
+
+// Example for APPROVED state
+{
+  "id": "MpykhM8sT1Tlid4Y6Y0d",
+  "userId": "dfdsd5T1Tlid4Y6Y0d",
+  "state": "APPROVED",
+  "from": 1709525300000,
+  "until": 1709870800000,
+  "message": "Attending a work conference.",
+  "createdAt": 1709525400000,
+  "updatedAt": 1709827800000,
+  "approvedAt": 1709827800000,
+  "approvedBy": "Sedv5T1Tlid4Y6Y0d"
+}
+
+// Example for REJECTED state
+{
+  "id": "Me8sT1Tlid4Y6Y0d",
+  "userId": "dfdsd5T1Tlid4Y6Y0d",
+  "state": "REJECTED",
+  "from": 1709603700000,
+  "until": 1709785600000,
+  "message": "Out of office for personal reasons.",
+  "createdAt": 1708763200000,
+  "updatedAt": 1708841500000,
+  "rejectedAt": 1708841500000,
+  "rejectedBy": "Sedv5T1Tlid4Y6Y0d",
+  "rejectedReason": "Not enough notice."
+}
+
+```

--- a/ooo-request/README.md
+++ b/ooo-request/README.md
@@ -4,7 +4,7 @@
 {
   "id": "String",
   "userId": "String",
-  "state": "PENDING" | "APPROVED" | "REJECTED",
+  "state": "<PENDING | APPROVED | REJECTED>",
   "from": "Timestamp",
   "until": "Timestamp",
   "message": "String",
@@ -32,8 +32,9 @@
 
 ### Example data
 
+#### Example for PENDING state
+
 ```json
-// Example for PENDING state
 {
   "id": "OfsT1Tlid4Y6Y0d",
   "userId": "dfdsd5T1Tlid4Y6Y0d",
@@ -44,8 +45,11 @@
   "createdAt": 1709438900000,
   "updatedAt": 1709438900000
 }
+```
 
-// Example for APPROVED state
+#### Example for APPROVED state
+
+```json
 {
   "id": "MpykhM8sT1Tlid4Y6Y0d",
   "userId": "dfdsd5T1Tlid4Y6Y0d",
@@ -58,8 +62,11 @@
   "processedBy": "Sedv5T1Tlid4Y6Y0d",
   "reason": "Nice to have you back."
 }
+```
 
-// Example for REJECTED state
+#### Example for REJECTED state
+
+```json
 {
   "id": "Me8sT1Tlid4Y6Y0d",
   "userId": "dfdsd5T1Tlid4Y6Y0d",
@@ -72,5 +79,4 @@
   "processedBy": "Sedv5T1Tlid4Y6Y0d",
   "reason": "Not enough vacation days."
 }
-
 ```


### PR DESCRIPTION
## [Read this doc](https://github.com/Real-Dev-Squad/website-data-models/blob/d642843434d1fed12d10700b338fb2ddd4aa979a/ooo-request/README.md)

### Parent Issue - https://github.com/Real-Dev-Squad/website-backend/issues/1821

### Description

This pull request introduces a new Firestore collection model for managing Out of Office (OOO) status requests. The model is designed to capture the various states of a request, including PENDING, APPROVED, and REJECTED. Additionally, it includes relevant information such as user ID, request timestamps, approval/rejection details, and messages associated with the request.

### Changes Made

- **Fields Added:**
  - `approvedAt`: Unix timestamp for the approval time of the request.
  - `approvedBy`: The user ID of the person who approved the request.
  - `rejectedAt`: Unix timestamp for the rejection time of the request.
  - `rejectedBy`: The user ID of the person who rejected the request.
  - `rejectedReason`: The reason for the rejection of the request.

- **State Field Modification:**
  - The `state` field now supports three possible values: "PENDING," "APPROVED," and "REJECTED."

- **Example Data:**
  - Provided examples for each state (PENDING, APPROVED, REJECTED) to illustrate the structure and usage of the model.

### Context

This Firestore collection model is intended to be used in applications where users can submit Out of Office requests, and superuser can approve or reject those requests. The additional fields capture essential information for tracking the status and history of each request.