### PR TITLE
feat: update user status data model

### DIFF
--- a/users-status/README.md
+++ b/users-status/README.md
@@ -23,8 +23,5 @@
     "updatedAt": "TimeStamp"
   },
   "idleWindowStartedAt": "Number | null",
-  "lastOooFrom": "Number | null",
-  "lastOooUntil": "Number | null",
-  "oooPeriods": "Array<{ from: Number, until: Number }>"
 }
 ```

--- a/users-status/README.md
+++ b/users-status/README.md
@@ -21,6 +21,10 @@
   "monthlyHours": {
     "committed": "Number",
     "updatedAt": "TimeStamp"
-  }
+  },
+  "idleWindowStartedAt": "Number | null",
+  "lastOooFrom": "Number | null",
+  "lastOooUntil": "Number | null",
+  "oooPeriods": "Array<{ from: Number, until: Number }>"
 }
 ```

--- a/users-status/README.md
+++ b/users-status/README.md
@@ -22,6 +22,6 @@
     "committed": "Number",
     "updatedAt": "TimeStamp"
   },
-  "idleWindowStartedAt": "Number | null",
+  "idleFrom": "Number | null",
 }
 ```


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 10-03-2026
<!--Developer Name Here-->
Developer Name: @vinit717 

## Issue Ticket Number
- closes #https://github.com/RealDevSquad/website-backend/issues/2038

## Description

Added new fields
- **`idleWindowStartedAt`** (number | null)  
  When the current idle window started (e.g., a task was completed). Set on `ACTIVE -> IDLE`; reset to `null` on `* -> ACTIVE`. Single source of truth for "idle from" so the window survives OOO transitions without being lost.
  
  *Why it is required:* `currentStatus.from` resets to "today" every time a user changes status (like returning from OOO). Without `idleWindowStartedAt` acting as a permanent anchor, their accumulated idle days would wrongly reset to zero after every vacation

  
### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
